### PR TITLE
Enable core dumps

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -62,6 +62,10 @@ for droplet in $droplets; do
   ssh root@${ip} "mkdir /root/.docker 2>/dev/null"
   scp ~/.docker/config.json root@${ip}:/root/.docker/
 
+  echo "Setting up for core dumps"
+  ssh root@${ip} "echo ulimit -c unlimited >/etc/profile.d/core_ulimit.sh"
+  ssh root@${ip} "env DEBIAN_FRONTEND=noninteractive apt-get -qqy install systemd-coredump"
+
 done
 
 echo "Clearing KV state"


### PR DESCRIPTION
Cores will go to /var/lib/systemd/coredump/, and will be compressed with
xz.