### PR TITLE
Include branch name in Droplet hostname; nits

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -3,7 +3,6 @@
 set -e
 
 tag="vol-test${BUILD:+-$BUILD}"
-consul_vm_tag=$tag-"consul"
 
 . test.env || true
 
@@ -26,7 +25,7 @@ ip=$(echo $KV_ADDR | perl -ne 'print "$1\n" if m/([0-9.]+)(:\d+)?$/;')
 hosts="$hosts $ip"
 
 # Formatting OCD.
-hosts="$(echo $hosts | tr -s ':space:')"
+hosts="$(echo "$hosts" | tr -s ':space:')"
 
 echo "Hosts: $hosts"
 for h in $hosts; do
@@ -42,7 +41,7 @@ done
 
 function destroy_do_runners()
 {
-    ids=( $($doctl_auth compute droplet list --tag-name $tag --format ID --no-header) )
+    ids=( $($doctl_auth compute droplet list --tag-name "$tag" --format ID --no-header) )
     if [[ ${#ids[@]} -eq 0 ]]; then
         echo "-- skipping"
         return
@@ -50,13 +49,13 @@ function destroy_do_runners()
 
     for id in "${ids[@]}"; do
         echo "deleting $id"
-        $doctl_auth compute droplet rm -f $id || true
+        $doctl_auth compute droplet rm -f "$id" || true
     done
 }
 
 function delete_tags()
 {
-    $doctl_auth compute tag delete -f $tag
+    $doctl_auth compute tag delete -f "$tag"
 }
 
 function MAIN()

--- a/docker-plugin/install/clear_plugin.sh
+++ b/docker-plugin/install/clear_plugin.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-rm_plugin='docker plugin rm soegarots/plugin:latest'
+# shellcheck disable=SC2086
+
+driver=notset
+
+# shellcheck disable=SC1091 source=../../test.env
+. ../../test.sh
+
+rm_plugin="docker plugin rm $driver"
 
 $PREFIX $rm_plugin
 $PREFIX2 $rm_plugin
 $PREFIX3 $rm_plugin
-

--- a/provision.sh
+++ b/provision.sh
@@ -123,7 +123,7 @@ function do_auth_init()
 function write_config()
 {
   echo "Clearing KV state"
-  [[ -n "$kv_addr" ]] && [[ -z "JENKINS_JOB" ]] && http delete "${kv_addr}/v1/kv/storageos?recurse"
+  [[ -n "$kv_addr" ]] && [[ -z "$JENKINS_JOB" ]] && http delete "${kv_addr}/v1/kv/storageos?recurse"
 
 cat << EOF > test.env
 export VOLDRIVER="${plugin_name}:${version}"

--- a/provision.sh
+++ b/provision.sh
@@ -85,16 +85,12 @@ function provision_do_nodes()
 
     echo "Enabling core dumps"
     ssh "root@${ip}" "echo ulimit -c unlimited >/etc/profile.d/core_ulimit.sh"
-    ssh "root@${ip}" "export DEBIAN_FRONTEND=noninteractive ; apt-get update ; apt-get -qqqy install systemd-coredump"
+    ssh "root@${ip}" "export DEBIAN_FRONTEND=noninteractive ; apt-get -qy update ; apt-get -qqqy install systemd-coredump"
 
     echo "Copying StorageOS CLI"
     scp -p $cli_binary root@${ip}:/usr/local/bin/storageos
     ssh root@${ip} "echo export STORAGEOS_USERNAME=storageos >>/root/.bashrc"
     ssh root@${ip} "echo export STORAGEOS_PASSWORD=storageos >>/root/.bashrc"
-
-    echo "Setting up for core dumps"
-    ssh root@${ip} "echo ulimit -c unlimited >/etc/profile.d/core_ulimit.sh"
-    ssh root@${ip} "export DEBIAN_FRONTEND=noninteractive ; apt-get update ; apt-get -qqy install systemd-coredump"
 
     echo "Enable NBD"
     ssh root@${ip} "modprobe nbd nbds_max=1024"

--- a/provision.sh
+++ b/provision.sh
@@ -6,7 +6,10 @@ declare -a ips
 plugin_name="${PLUGIN_NAME:-soegarots/plugin}"
 version="${VERSION:-latest}"
 cli_version="${CLI_VERSION:-0.0.11}"
-tag="vol-test${BUILD:+-$BUILD}"
+
+branch_env="${BRANCH_ENV:-branchnotset}"
+build_id="${branch_env}-${BUILD:-buildnotset}"
+tag="vol-test-${build_id}"
 region=lon1
 size=2gb
 name_template="${tag}-${size}-${region}"

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -1,14 +1,16 @@
 #!/usr/bin/env bats
 
+# shellcheck disable=SC2034,SC2153
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 load "$DIR/test/test_helper/bats-support/load.bash"
 load "$DIR/test/test_helper/bats-assert/load.bash"
 
-driver=$VOLDRIVER
-prefix=$PREFIX
-prefix2=$PREFIX2
-prefix3=$PREFIX3
+driver="$VOLDRIVER"
+prefix="$PREFIX"
+prefix2="$PREFIX2"
+prefix3="$PREFIX3"
 createopts="$CREATEOPTS"
 pluginopts="$PLUGINOPTS"
 cliopts="$CLIOPTS"


### PR DESCRIPTION
If we only use the build number in droplet hostnames, one pipeline can attempt to reuse, recreate or delete another pipeline's droplet. Which sucks.